### PR TITLE
deposit_event<T>()

### DIFF
--- a/2/2.2-creating-an-event.md
+++ b/2/2.2-creating-an-event.md
@@ -45,13 +45,13 @@ In order to use events within your runtime, you need to add a function which dep
 Simply add a new function to your module like so:
 
 ```rust
-fn deposit_event<T> = default;
+fn deposit_event<T>() = default;
 ```
 
 If your events do not use any generics (e.g. just Rust primitive types), you should omit the `<T>` like this:
 
 ```rust
-fn deposit_event = default;
+fn deposit_event() = default;
 ```
 
 The `decl_module!` macro will detect this line, and replace it with the appropriate function definition for your runtime.


### PR DESCRIPTION
It looks like this is the correct syntax for declaring deposit_event.

otherwise I get loads of errors, as in the following excerpt:

```
error: no rules expected the token `normalize`
  --> src/substratekitties.rs:39:1
   |
39 | / decl_module! {
40 | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
41 | |
42 | |         fn deposit_event<T: Trait> = default;
...  |
73 | |     }
74 | | }
   | |_^ no rules expected this token in macro call
   |
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `Module` in `substratekitties`
   --> src/lib.rs:201:1
    |
201 | / construct_runtime!(
202 | |     pub enum Runtime with Log(InternalLog: DigestItem<Hash, Ed25519AuthorityId>) where
203 | |         Block = Block,
204 | |         NodeBlock = opaque::Block,
...   |
215 | |     }
216 | | );
    | |__^ could not find `Module` in `substratekitties`
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

error[E0412]: cannot find type `Module` in this scope
  --> src/substratekitties.rs:31:21
   |
31 |     trait Store for Module<T: Trait> as KittyStorage {
   |                     ^^^^^^ not found in this scope
help: possible candidates are found in other modules, you can import them into scope
   |
1  | use aura::Module;
   |
1  | use balances::Module;
   |
1  | use consensus::Module;
   |
1  | use indices::Module;
   |
and 3 other candidates

error[E0412]: cannot find type `Module` in module `substratekitties`
   --> src/lib.rs:201:1
    |
201 | / construct_runtime!(
202 | |     pub enum Runtime with Log(InternalLog: DigestItem<Hash, Ed25519AuthorityId>) where
203 | |         Block = Block,
204 | |         NodeBlock = opaque::Block,
...   |
215 | |     }
216 | | );
    | |__^ not found in `substratekitties`
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
help: possible candidates are found in other modules, you can import them into scope
    |
35  | use aura::Module;
    |
35  | use balances::Module;
    |
35  | use consensus::Module;
    |
35  | use indices::Module;
    |
and 3 other candidates
```