### PR TITLE
docs: Various fixes to Section 4 and 5

### DIFF
--- a/0/0.3-interacting-with-your-node.md
+++ b/0/0.3-interacting-with-your-node.md
@@ -33,6 +33,6 @@ Here you can see just how quickly we set up, ran, and interacted with our own lo
 ---
 **Learn More**
 
-The [Bonds UI](https://github.com/paritytech/substrate-ui) that has been built using the [oo7-substrate library](https://github.com/paritytech/oo7/tree/master/packages/oo7-substrate) is an alternative front-end interface to the [Polkadot-JS Apps UI](https://github.com/polkadot-js/apps) for interacting with your Substrate chain.
+The [Substrate UI](https://github.com/paritytech/substrate-ui) that has been built using the [oo7-substrate library](https://github.com/paritytech/oo7/tree/master/packages/oo7-substrate) is an alternative front-end interface to the [Polkadot-JS Apps UI](https://github.com/polkadot-js/apps) for interacting with your Substrate chain.
 
 When building your own UI, remember to refer to the [Polkadot-JS API Documentation](https://github.com/polkadot-js/api) and the [oo7 API Documentation](https://tomusdrw.github.io/oo7/).

--- a/4/4.0-introduction.md
+++ b/4/4.0-introduction.md
@@ -7,6 +7,6 @@ Since this course is primarily about runtime development, what you will learn in
 
 ## What to Expect
 
-We will be using a React template called the Substrate UI which is built using a custom oo7 javascript
+We will be using a React template called the [Substrate UI](https://github.com/paritytech/substrate-ui) which is built using the [oo7-substrate library](https://github.com/paritytech/oo7/tree/master/packages/oo7-substrate). It is an alternative front-end interface to the [Polkadot-JS Apps UI](https://github.com/polkadot-js/apps) for interacting with your Substrate chain.
 
-[TODO: Finish this]
+When building your own UI, remember to refer to the [Polkadot-JS API Documentation](https://github.com/polkadot-js/api) and the [oo7 API Documentation](https://tomusdrw.github.io/oo7/).

--- a/4/4.1-set-up-substrate-ui.md
+++ b/4/4.1-set-up-substrate-ui.md
@@ -1,7 +1,7 @@
 Set Up Substrate UI
 ===
 
-Similar to the `substrate-node-new` command you used way back at the beginning of this tutorial, when you install substrate, we also provide you with a `substrate-ui-new` command which will automatically clone the [`substrate-ui` repo](https://github.com/paritytech/substrate-ui/tree/substrate-node-template) on your computer.
+Similar to the `substrate-node-new` command you used way back at the beginning of this tutorial, when you install Substrate, we also provide you with a `substrate-ui-new` command which will automatically clone the [`substrate-ui` repo](https://github.com/paritytech/substrate-ui/tree/substrate-node-template) on your computer.
 
 ## Install the Substrate UI
 
@@ -9,15 +9,16 @@ For the best experience working with the Substrate UI repo, you should install `
 
 [Install Yarn](https://yarnpkg.com/lang/en/docs/install/)
 
-Run the following command in your working folder:
+Run the following command in your working folder, as indicated by the usage instructions `substrate-ui-new --help`:
 
 ```
 substrate-ui-new substratekitties
 ```
 
-You should see that a new folder is created where the `substrate-ui` repo is cloned. In that folder, install the required packages using:
+You should see that a new folder `<NAME>-ui` is created where the `substrate-ui` repo is cloned. In that folder, install the required packages using:
 
 ```
+cd substratekitties-ui
 yarn install
 ```
 
@@ -32,7 +33,7 @@ Make sure your node is up and running and open `localhost:8000` in your Chrome.
 ----
 _Note_:
 
-The UI uses websockets to connect to the local node instance through an unecrypted connection. Most Browsers disallow this kind of connection for security and privacy reasons, only Chrome allows this connection _if it is connecting to localhost_. That is why we are using Chrome in this workshop. If you want to connect to the browser to a different computer in the network, it must be served through a secured connection.
+The UI uses websockets to connect to the local node instance through an unencrypted connection. Most Browsers disallow this kind of connection for security and privacy reasons, only Chrome allows this connection _if it is connecting to localhost_. That is why we are using Chrome in this workshop. If you want to connect to the browser to a different computer in the network, it must be served through a secured connection.
 
 ----
 

--- a/4/4.2-explore.md
+++ b/4/4.2-explore.md
@@ -4,7 +4,7 @@ The Substrate UI has a lot going on inside. We will try to simplify some of the 
 
 ## Bare Bones Substrate UI
 
-The `substrate-ui` template comes with a number of prebuilt features that you might expect for the average Blockchain UI.
+The `substrate-ui` template comes with a number of prebuilt features that you might expect from the average Blockchain UI.
 
 - A wallet to manage and create keys + accounts
 - An address book to get details about accounts
@@ -19,7 +19,7 @@ You might try this if you make logical changes to some of your functions as sugg
 
 ## React Components
 
-If you peak into the Substrate UI code, you will see that it is made up of React Components each which serve their own purpose. As mentioned, the Substrate UI comes with a set of prebuilt features, and you can find the components which power those features in the `src` folder.
+If you peak into the Substrate UI code, you will see that it is made up of React Components that each serve their own purpose. As mentioned, the Substrate UI comes with a set of prebuilt features, and you can find the components which power those features in the `src` folder.
 
 All of these components are put together in the `src/app.jsx` file which powers the main view that you see.
 
@@ -35,7 +35,7 @@ If we go into the console and type `runtime.` (note the dot at the end), we shou
 
 ![An image of the runtime autocomplete](./assets/runtime-autocomplete.png)
 
-You might notice that these are our modules! Better yet, we can see `susbtratekitties`. Let's go deeper.
+You might notice that these are our modules! Better yet, we can see `substratekitties`. Let's go deeper.
 
 ![An image of the substratekitties autocomplete](./assets/substratekitties-autocomplete.png)
 

--- a/4/4.3-creating-kitties.md
+++ b/4/4.3-creating-kitties.md
@@ -8,7 +8,9 @@ Interacting with the new feature
 
 [TODO: Update this section]
 
-The `oo7` library small library providing what might be termed as reactive expressions, Bonds (hence the name). Classes deriving from Bond are expected to determine when their value has changed and call trigger accordingly.
+The `oo7` library small library providing what might be termed as reactive expressions, Bonds (hence the name). Classes deriving from Bond are expected to be determined when their value has changed and call trigger accordingly.
+
+Remember to refer to the [oo7 API Documentation](https://tomusdrw.github.io/oo7/).
 
 ## Creating a New Bond
 
@@ -26,4 +28,4 @@ You enjoy building the UI? We have more features in the runtime you could implem
 
 ### What else?
 
-Or you have a different idea what kitties could do? Maybe they want to be feed or fight with one another? Go nuts!
+Or you have a different idea of what kitties could do? Maybe they want to be feed or fight with one another? Go nuts!

--- a/5/5.0-wrapping-up.md
+++ b/5/5.0-wrapping-up.md
@@ -3,4 +3,4 @@
 ## What else could be done?
 
 
-## Join us on reddit!
+## [Join us on reddit!](https://www.reddit.com/r/substrate/)


### PR DESCRIPTION
* Rename Bonds UI to Substrate UI for consistency in the workshop

* Add links to Substrate UI and its associated API docs to Section 4

* Make it clearer what `substrate-ui-new` is actually doing

* Add missing link to Substrate on Reddit