### PR TITLE
refactor: Various modifications to Chapter 4. See commit details

### DIFF
--- a/0/interacting-with-your-node.md
+++ b/0/interacting-with-your-node.md
@@ -35,4 +35,4 @@ Here you can see just how quickly we set up, ran, and interacted with our own lo
 
 The [Substrate UI](https://github.com/paritytech/substrate-ui) that has been built using the [oo7-substrate library](https://github.com/paritytech/oo7/tree/master/packages/oo7-substrate) is an alternative front-end interface to the [Polkadot-JS Apps UI](https://github.com/polkadot-js/apps) for interacting with your Substrate chain.
 
-When building your own UI, remember to refer to the [Polkadot-JS API Documentation](https://github.com/polkadot-js/api) and the [oo7 API Documentation](https://tomusdrw.github.io/oo7/).
+When building your own UI, remember to refer to the [Polkadot-JS API Documentation](https://polkadot.js.org/api/) and the [oo7 API Documentation](https://tomusdrw.github.io/oo7/).

--- a/4/creating-kitties.md
+++ b/4/creating-kitties.md
@@ -29,7 +29,7 @@ So let's try to make a call to create a new kitty. To do that, we can make a `po
 
 ```javascript
 post({
-    sender: "5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ",
+    sender: '5GoKvZWG5ZPYL1WUovuHW3zJBWBP5eT8CbqjdRY4Q6iMaDtZ',
     call: calls.substratekitties.createKitty()
 }).tie(console.log)
 ```
@@ -48,7 +48,7 @@ Now that we know how to make a call to our runtime, we will want to integrate th
 
 If you look at the code for the other sections on the page, you will find examples of how to integrate these parts.
 
-The `SignerBond` creates an input field where a person can write the name of the account they want to sign some message. This account gets placed inside of a `bond`.
+The `SignerBond` creates an input field where a person can write the name of the account they want to sign some message with. This account gets placed inside of a `bond`.
 
 ```javascript
 this.account = new Bond;
@@ -60,7 +60,7 @@ You can then use this bond to power a `TransactButton`, where we will use the va
 
 ```javascript
 <TransactButton
-    content="Submit Transaction"
+    content='Submit Transaction'
     icon='send'
     tx={{
         sender: runtime.indices.tryIndex(this.account),

--- a/4/explore.md
+++ b/4/explore.md
@@ -71,9 +71,9 @@ You can see that this example runtime has 8 kitties, all of which you can access
 
 We can start off simple and try to update the Substrate UI to include a live kitty count on the page.
 
-The variables we showed above are Bonds, which means their values will update automatically as changes to your blockchain happen. However, that also means that you need to work with these variables a little differently than normal (note that we used promises in the example above).
+The variables we showed above are Bonds, which means their values will update automatically as changes to your blockchain happen. However, that also means that you need to work with these variables a little differently than normal (note that we used JavaScript Promises in the example above).
 
-Fortunately, for our example, we will use some of the components already built for us. In this case we will use an aptly-named component called `Pretty` which turns most any bond into a readable string. You can see it being used on other parts of the page.
+Fortunately, for our example, we will use some of the components already built for us. In this case we will use an aptly-named component called `Pretty` which turns almost any bond into a readable string. You can see it being used on other parts of the page.
 
 In our example blockchain:
 

--- a/4/introduction.md
+++ b/4/introduction.md
@@ -9,4 +9,4 @@ Since this course is primarily about runtime development, what you will learn in
 
 We will be using a React template called the [Substrate UI](https://github.com/paritytech/substrate-ui) which is built using the [oo7-substrate library](https://github.com/paritytech/oo7/tree/master/packages/oo7-substrate). It is an alternative front-end interface to the [Polkadot-JS Apps UI](https://github.com/polkadot-js/apps) for interacting with your Substrate chain.
 
-When building your own UI, remember to refer to the [Polkadot-JS API Documentation](https://github.com/polkadot-js/api) and the [oo7 API Documentation](https://tomusdrw.github.io/oo7/).
+When building your own UI, remember to refer to the [Polkadot-JS API Documentation](https://polkadot.js.org/api/) and the [oo7 API Documentation](https://tomusdrw.github.io/oo7/).

--- a/4/rendering-kitties.md
+++ b/4/rendering-kitties.md
@@ -5,7 +5,7 @@ If you made it this far, then you have truly earned what we are about to do in t
 
 ## Adding Our Custom `KittyCard` Component
 
-We have built a custom React component for showing kitties. It is not so complicated, but for the purposes of this workshop, we will not have you build it. You can download the component as a `.zip` [here](./assets/KittyCards.zip).
+We have built a custom React component for showing kitties. It is not so complicated, but for the purposes of this workshop, we will not have you build it. You can download the component as a `.zip` [here](https://github.com/shawntabrizi/substrate-collectables-workshop/raw/master/4/assets/KittyCards.zip).
 
 To add it, you must place the `KittyCards` folder in your `src` folder:
 
@@ -26,18 +26,18 @@ substratekitties-ui
 Then, inside the main `app.jsx` file you need to import this component:
 
 ```javascript
-import {KittyCards} from './KittyCards';
+import { KittyCards } from './KittyCards';
 ```
 
 This will give you access to the `<KittyCards>` component:
 
 ```
-<KittyCards count={runtime.substratekitties.allKittiesCount}/>
+<KittyCards count={runtime.substratekitties.allKittiesCount} />
 ```
 
 ### Add the `Kitty` Type
 
-Before this component will work, we need to add tell the Substrate UI about our custom `Kitty` type. We can do that with the `addCodecTransform()` function made available to us by the oo7 JavaScript.
+Before this component will work, we need to tell the Substrate UI about our custom `Kitty` type. We can do that with the `addCodecTransform()` function made available to us by the oo7 JavaScript library.
 
 In the case of our kitty object, it would look like this:
 
@@ -52,7 +52,7 @@ addCodecTransform('Kitty<Hash,Balance>', {
 
 We can add this to our application's `constructor()` function to ensure it gets loaded at the start. After this, we can interact with the attributes of the `Kitty` object like we could any other JSON object.
 
-> Note: The codec transform uses a key/value pair to look up the object structure that should be used for deserialization. As a result, it is important that your "object name" matches exactly what is expected. In this situation, note there are no spaces in the object name. If the Substrate UI cannot find the right key for a custom object, it will give you an error in your browser console with the exact object name it is expecting.
+> Note: The codec transform uses a key/value pair to look up the object structure that should be used for deserialization. As a result, it is important that your "object name" matches exactly what is expected. In this situation, note there are no spaces in the object name `Kitty<Hash,Balance>`. If the Substrate UI cannot find the right key for a custom object, it will give you an error in your browser console with the exact object name it is expecting.
 
 ## Peek Inside Our Custom Component
 
@@ -64,10 +64,10 @@ Since we won't have you build this component, we will show you some of the worki
 
 Let's quickly walk through the parts of `/KittyCards/index.jsx` to show how we are able to dynamically load new cards when kitties are added to the system.
 
-We call the `KittyCard` component from our  UI with:
+We call the `KittyCard` component from our UI with:
 
 ```
-<KittyCards count={runtime.substratekitties.allKittiesCount}/>
+<KittyCards count={runtime.substratekitties.allKittiesCount} />
 ```
 
 This component is tied to the `allKittiesCount` bond, that will automatically update as the state of our blockchain changes.
@@ -77,6 +77,7 @@ When `allKittiesCount` changes, the `readyRender()` part of our `KittyCards` com
 ```javascript
     readyRender() {
         let kitties = [];
+
         for (var i=0; i < this.state.count; i++){
             kitties.push(
                 <div className="column" key={i}>
@@ -86,24 +87,31 @@ When `allKittiesCount` changes, the `readyRender()` part of our `KittyCards` com
         }
 ```
 
-This then send the kitty id `Hash` to the `KittyWrap` component which does a simple lookup for the `owner` and the `Kitty` object. If the `hash` sent to `KittyWrap` doesn't change between loops, then React will simply skip the re-rendering process.
+This then sends the kitty id `Hash` to the `KittyWrap` component which does a simple lookup for the `owner` and the `Kitty` object. If the `hash` sent to `KittyWrap` doesn't change between loops, then React will simply skip the re-rendering process.
 
 ```javascript
 class KittyWrap extends ReactiveComponent {
     constructor(props) {
-        super(['hash'])
+        super(['hash']);
     }
 
     readyRender() {
-        return <KittyCard
-            kitty={runtime.substratekitties.kitties(this.state.hash)}
-            owner={runtime.substratekitties.kittyOwner(this.state.hash)}
-        />
+        const { hash } = this.state; // Object destructuring assignment syntax
+
+        return (
+            <KittyCard
+                kitty={runtime.substratekitties.kitties(hash)}
+                owner={runtime.substratekitties.kittyOwner(hash)}
+            />
+        );
     }
 }
 ```
 
 Finally, `KittyWrap` calls `KittyCard` which actually produces the contents of each card.
+
+Note that we have used JavaScript [Object Destructuring Assignment Syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Object_destructuring) to unpack the `hash` property from
+`this.state` since we are reusing the value multiple times (rather than repeatedly having to write `this.state.hash`).
 
 ### Card Contents
 
@@ -119,15 +127,31 @@ Our `KittyCard` component takes the `Kitty` object passed from `KittyWrap`, as w
 <Card>
     <KittyAvatar dna={kitty.dna} />
     <Card.Content>
-        <Card.Header><Pretty value={kitty.id} className="limit-name" /></Card.Header>
+        <Card.Header>
+            <Pretty
+                value={kitty.id}
+                className='limit-name'
+            />
+        </Card.Header>
         <Card.Meta>
-            <Pretty value={kitty.dna} className="limit-dna" />
+            <Pretty
+                value={kitty.dna}
+                className='limit-dna'
+            />
         </Card.Meta>
         <Rspan>
-            <b>Owner</b>: {secretStore().find(this.state.owner).name}
+            <b>Owner</b>: {
+                secretStore()
+                    .find(this.state.owner)
+                    .name
+            }
         </Rspan>
         &nbsp;
-        <Identicon key={this.state.owner} account={this.state.owner} size={16}/>
+        <Identicon
+            key={this.state.owner}
+            account={this.state.owner}
+            size={16}
+        />
         <br />
         <Rspan>
             <b>Generation</b>: {kitty.gen}
@@ -135,7 +159,10 @@ Our `KittyCard` component takes the `Kitty` object passed from `KittyWrap`, as w
         <br />
     </Card.Content>
     <Card.Content extra>
-        <Pretty value={kitty.price} prefix="$" />
+        <Pretty
+            value={kitty.price}
+            prefix='$'
+        />
     </Card.Content>
 </Card>;
 ```
@@ -152,9 +179,7 @@ The core function in the component is `dnaToAttributes()`:
 
 ```
 function dnaToAttributes(dna) {
-    let attribute = (index, options) => {
-        return dna[index] % options
-    };
+    let attribute = (index, options) => dna[index] % options;
 
     return {
         body: IMAGES.body[attribute(0, 15)],
@@ -162,7 +187,7 @@ function dnaToAttributes(dna) {
         accessory: IMAGES.accessories[attribute(2, 20)],
         fur: IMAGES.fur[attribute(3, 10)],
         mouth: IMAGES.mouth[attribute(4, 10)]
-    }
+    };
 } 
 ```
 

--- a/4/set-up-substrate-ui.md
+++ b/4/set-up-substrate-ui.md
@@ -29,12 +29,12 @@ And once the packages are done you can run the UI using:
 yarn run dev
 ```
 
-Make sure your node is up and running and open `localhost:8000` in your Chrome.
+Make sure your Substrate node is up and running and open [localhost:8000](http://localhost:8000) in your Chrome browser.
 
 ----
 _Note_:
 
-The UI uses websockets to connect to the local node instance through an unencrypted connection. Most Browsers disallow this kind of connection for security and privacy reasons, only Chrome allows this connection _if it is connecting to localhost_. That is why we are using Chrome in this workshop. If you want to connect to the browser to a different computer in the network, it must be served through a secured connection.
+The UI uses WebSockets to connect to the local Substrate node instance through an unencrypted connection. Most Browsers disallow this kind of connection for security and privacy reasons, only Chrome allows this connection _if it is connecting to localhost_. That is why we are using Chrome in this workshop. If you want to connect to the browser using a different computer in the network, it must be served through a secured connection.
 
 _Note_:
 


### PR DESCRIPTION
* Fixes link at https://shawntabrizi.github.io/substrate-collectables-workshop/#/4/rendering-kitties that is supposed to link to the KittyCards component zip file but is broken and returns 404 page https://shawntabrizi.github.io/substrate-collectables-workshop/#/./assets/KittyCards.zip

* Link directly to Polkadot-JS API docs instead of just its GitHub repo (since the docs page links back to the GitHub repo already)

* Remove unnecessary use of double quotes

* Add spaces around component names when importing

* Add space at end of component

* Various spelling/grammar fixes

* Add missing semicolons

* Show component properties across multiple lines when multiple props (more readable in browser too)

* Show use of Object destructuring assignment in an example