### PR TITLE
add missing use for Encode and Decode traits

### DIFF
--- a/1/assets/1.6-finished-code.rs
+++ b/1/assets/1.6-finished-code.rs
@@ -1,6 +1,7 @@
 use support::{decl_storage, decl_module, StorageMap, dispatch::Result};
 use system::ensure_signed;
 use runtime_primitives::traits::{As, Hash};
+use parity_codec_derive::{Encode, Decode};
 
 #[derive(Encode, Decode, Default, Clone, PartialEq)]
 pub struct Kitty<Hash, Balance> {


### PR DESCRIPTION
Hi, without this `use` i was getting:
```
error: cannot find derive macro `Decode` in this scope
 --> /home/fgimenez/workspace/substratekitties/runtime/src/substratekitties.rs:7:18
  |
7 | #[derive(Encode, Decode, Default, Clone, PartialEq)]
  |                  ^^^^^^

error: cannot find derive macro `Encode` in this scope
 --> /home/fgimenez/workspace/substratekitties/runtime/src/substratekitties.rs:7:10
  |
7 | #[derive(Encode, Decode, Default, Clone, PartialEq)]
  |          ^^^^^^

error[E0277]: the trait bound `substratekitties::Kitty<<T as srml_system::Trait>::Hash, <T as srml_balances::Trait>::Balance>: _IMPL_DECODE_FOR_Event::_parity_codec::Decode` is not satisfied
  --> /home/fgimenez/workspace/substratekitties/runtime/src/substratekitties.rs:15:1
   |
15 | / decl_storage! {
16 | |     trait Store for Module<T: Trait> as KittyStorage {
17 | |         OwnedKitty: map T::AccountId => Kitty<T::Hash, T::Balance>
18 | |     }
19 | | }
   | |_^ the trait `_IMPL_DECODE_FOR_Event::_parity_codec::Decode` is not implemented for `substratekitties::Kitty<<T as srml_system::Trait>::Hash, <T as srml_balances::Trait>::Balance>`

error[E0277]: the trait bound `substratekitties::Kitty<<T as srml_system::Trait>::Hash, <T as srml_balances::Trait>::Balance>: _IMPL_DECODE_FOR_Event::_parity_codec::Encode` is not satisfied
  --> /home/fgimenez/workspace/substratekitties/runtime/src/substratekitties.rs:15:1
   |
15 | / decl_storage! {
16 | |     trait Store for Module<T: Trait> as KittyStorage {
17 | |         OwnedKitty: map T::AccountId => Kitty<T::Hash, T::Balance>
18 | |     }
19 | | }
   | |_^ the trait `_IMPL_DECODE_FOR_Event::_parity_codec::Encode` is not implemented for `substratekitties::Kitty<<T as srml_system::Trait>::Hash, <T as srml_balances::Trait>::Balance>`
```
Thanks!