### PR TITLE
Changed '$' to "$" - it was confusing github pages

### DIFF
--- a/4/rendering-kitties.md
+++ b/4/rendering-kitties.md
@@ -161,7 +161,7 @@ Our `KittyCard` component takes the `Kitty` object passed from `KittyWrap`, as w
     <Card.Content extra>
         <Pretty
             value={kitty.price}
-            prefix='$'
+            prefix="$"
         />
     </Card.Content>
 </Card>;


### PR DESCRIPTION
It looked ok when viewed as markdown on github but Github pages was freaking out with single quote. It messes up the rendering of the rest of page.