### PR TITLE
Fix path to init.sh

### DIFF
--- a/0/running-a-custom-node.md
+++ b/0/running-a-custom-node.md
@@ -31,7 +31,7 @@ Then let's go into the now renamed `substratekitties` folder and build our pre-c
 
 ```bash
 cd substratekitties
-./init.sh
+./scripts/init.sh
 ./scripts/build.sh
 cargo build --release
 ```


### PR DESCRIPTION
Small error: But in running-a-custom-node.md, "./init.sh" should be "./scripts/init.sh"