### PR TITLE
How to write tests section for Substrate Kitties

### DIFF
--- a/5/assets/5.1-finished-code.rs
+++ b/5/assets/5.1-finished-code.rs
@@ -287,8 +287,6 @@ mod tests {
 	}
 
 	type Kitties = super::Module<KittiesTest>;
-	type Balances = balances::Module<KittiesTest>;
-	type System = system::Module<KittiesTest>;
 
 	fn build_ext() -> TestExternalities<Blake2Hasher> {
 		let mut t = system::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0;

--- a/5/assets/5.1-finished-code.rs
+++ b/5/assets/5.1-finished-code.rs
@@ -255,13 +255,9 @@ mod tests {
 		pub enum Origin for KittiesTest {}
 	}
 
-	// Create one configuration type (`Test`) which `impl`s each of the
-	// configuration traits of modules we want to use.
 	#[derive(Clone, Eq, PartialEq)]
 	pub struct KittiesTest;
 
-	// Start implementing the Trait's of all the other modules that you need.
-	// If you want anything that is reasonably functional you also need to implement the System trait.
 	impl system::Trait for KittiesTest {
 		type Origin = Origin;
 		type Index = u64;
@@ -276,8 +272,6 @@ mod tests {
 		type Log = DigestItem;
 	}
 	
-    // And any other trait that your Trait is explicitly bounded by.
-	// Remember you had: `pub trait Trait: balances::Trait`
 	impl balances::Trait for KittiesTest {
 		type Balance = u64;
 		type OnFreeBalanceZero = ();
@@ -288,12 +282,10 @@ mod tests {
 		type DustRemoval = ();
 	}
 
-	// And finally, your own trait.
 	impl super::Trait for KittiesTest {
 		type Event = ();
 	}
 
-	// Creates aliases for modules for easier access
 	type Kitties = super::Module<KittiesTest>;
 	type Balances = balances::Module<KittiesTest>;
 	type System = system::Module<KittiesTest>;
@@ -301,7 +293,6 @@ mod tests {
 	fn build_ext() -> TestExternalities<Blake2Hasher> {
 		let mut t = system::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0;
 		t.extend(balances::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0);
-		// t.extend(GenesisConfig::<KittiesTest>::default().build_ext().unwrap().0);
 		t.into()
 	}
 }

--- a/5/assets/5.2-finished-code.rs
+++ b/5/assets/5.2-finished-code.rs
@@ -240,8 +240,6 @@ impl<T: Trait> Module<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-	// Import a bunch of dependencies from substrate core. All needed for some parts of the code.
 	use support::{impl_outer_origin, assert_ok, assert_noop};
 	use runtime_io::{with_externalities, TestExternalities};
 	use primitives::{H256, Blake2Hasher};
@@ -255,13 +253,9 @@ mod tests {
 		pub enum Origin for KittiesTest {}
 	}
 
-	// Create one configuration type (`Test`) which `impl`s each of the
-	// configuration traits of modules we want to use.
 	#[derive(Clone, Eq, PartialEq)]
 	pub struct KittiesTest;
 
-	// Start implementing the Trait's of all the other modules that you need.
-	// If you want anything that is reasonably functional you also need to implement the System trait.
 	impl system::Trait for KittiesTest {
 		type Origin = Origin;
 		type Index = u64;
@@ -276,8 +270,6 @@ mod tests {
 		type Log = DigestItem;
 	}
 	
-    // And any other trait that your Trait is explicitly bounded by.
-	// Remember you had: `pub trait Trait: balances::Trait`
 	impl balances::Trait for KittiesTest {
 		type Balance = u64;
 		type OnFreeBalanceZero = ();
@@ -288,12 +280,10 @@ mod tests {
 		type DustRemoval = ();
 	}
 
-	// And finally, your own trait.
 	impl super::Trait for KittiesTest {
 		type Event = ();
 	}
 
-	// Creates aliases for modules for easier access
 	type Kitties = super::Module<KittiesTest>;
 	type Balances = balances::Module<KittiesTest>;
 	type System = system::Module<KittiesTest>;
@@ -301,7 +291,6 @@ mod tests {
 	fn build_ext() -> TestExternalities<Blake2Hasher> {
 		let mut t = system::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0;
 		t.extend(balances::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0);
-		// t.extend(GenesisConfig::<KittiesTest>::default().build_ext().unwrap().0);
 		t.into()
 	}
 

--- a/5/assets/5.2-finished-code.rs
+++ b/5/assets/5.2-finished-code.rs
@@ -285,8 +285,6 @@ mod tests {
 	}
 
 	type Kitties = super::Module<KittiesTest>;
-	type Balances = balances::Module<KittiesTest>;
-	type System = system::Module<KittiesTest>;
 
 	fn build_ext() -> TestExternalities<Blake2Hasher> {
 		let mut t = system::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0;

--- a/5/assets/5.2-template.rs
+++ b/5/assets/5.2-template.rs
@@ -240,8 +240,6 @@ impl<T: Trait> Module<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-	// Import a bunch of dependencies from substrate core. All needed for some parts of the code.
 	use support::{impl_outer_origin, assert_ok, assert_noop};
 	use runtime_io::{with_externalities, TestExternalities};
 	use primitives::{H256, Blake2Hasher};
@@ -255,13 +253,9 @@ mod tests {
 		pub enum Origin for KittiesTest {}
 	}
 
-	// Create one configuration type (`Test`) which `impl`s each of the
-	// configuration traits of modules we want to use.
 	#[derive(Clone, Eq, PartialEq)]
 	pub struct KittiesTest;
 
-	// Start implementing the Trait's of all the other modules that you need.
-	// If you want anything that is reasonably functional you also need to implement the System trait.
 	impl system::Trait for KittiesTest {
 		type Origin = Origin;
 		type Index = u64;
@@ -276,8 +270,6 @@ mod tests {
 		type Log = DigestItem;
 	}
 	
-    // And any other trait that your Trait is explicitly bounded by.
-	// Remember you had: `pub trait Trait: balances::Trait`
 	impl balances::Trait for KittiesTest {
 		type Balance = u64;
 		type OnFreeBalanceZero = ();
@@ -288,12 +280,10 @@ mod tests {
 		type DustRemoval = ();
 	}
 
-	// And finally, your own trait.
 	impl super::Trait for KittiesTest {
 		type Event = ();
 	}
 
-	// Creates aliases for modules for easier access
 	type Kitties = super::Module<KittiesTest>;
 	type Balances = balances::Module<KittiesTest>;
 	type System = system::Module<KittiesTest>;
@@ -301,7 +291,6 @@ mod tests {
 	fn build_ext() -> TestExternalities<Blake2Hasher> {
 		let mut t = system::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0;
 		t.extend(balances::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0);
-		// t.extend(GenesisConfig::<KittiesTest>::default().build_ext().unwrap().0);
 		t.into()
 	}
 

--- a/5/assets/5.2-template.rs
+++ b/5/assets/5.2-template.rs
@@ -285,8 +285,6 @@ mod tests {
 	}
 
 	type Kitties = super::Module<KittiesTest>;
-	type Balances = balances::Module<KittiesTest>;
-	type System = system::Module<KittiesTest>;
 
 	fn build_ext() -> TestExternalities<Blake2Hasher> {
 		let mut t = system::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0;

--- a/5/assets/5.3-finished-code.rs
+++ b/5/assets/5.3-finished-code.rs
@@ -262,8 +262,6 @@ impl<T: Trait> Module<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-	// Import a bunch of dependencies from substrate core. All needed for some parts of the code.
 	use support::{impl_outer_origin, assert_ok, assert_noop};
 	use runtime_io::{with_externalities, TestExternalities};
 	use primitives::{H256, Blake2Hasher};
@@ -277,13 +275,8 @@ mod tests {
 		pub enum Origin for KittiesTest {}
 	}
 
-	// Create one configuration type (`Test`) which `impl`s each of the
-	// configuration traits of modules we want to use.
 	#[derive(Clone, Eq, PartialEq)]
 	pub struct KittiesTest;
-
-	// Start implementing the Trait's of all the other modules that you need.
-	// If you want anything that is reasonably functional you also need to implement the System trait.
 	impl system::Trait for KittiesTest {
 		type Origin = Origin;
 		type Index = u64;
@@ -298,8 +291,6 @@ mod tests {
 		type Log = DigestItem;
 	}
 	
-    // And any other trait that your Trait is explicitly bounded by.
-	// Remember you had: `pub trait Trait: balances::Trait`
 	impl balances::Trait for KittiesTest {
 		type Balance = u64;
 		type OnFreeBalanceZero = ();
@@ -310,12 +301,10 @@ mod tests {
 		type DustRemoval = ();
 	}
 
-	// And finally, your own trait.
 	impl super::Trait for KittiesTest {
 		type Event = ();
 	}
 
-	// Creates aliases for modules for easier access
 	type Kitties = super::Module<KittiesTest>;
 	type Balances = balances::Module<KittiesTest>;
 	type System = system::Module<KittiesTest>;

--- a/5/assets/5.3-finished-code.rs
+++ b/5/assets/5.3-finished-code.rs
@@ -323,8 +323,8 @@ mod tests {
 			// create a kitty with account #10.
             assert_ok!(Kitties::create_kitty(Origin::signed(10)));
 
-            // check that there is now 1 kitty in storage
-            assert_eq!(Kitties::all_kitties_count(), 1);
+            // check that there are now 3 kitties in storage
+            assert_eq!(Kitties::all_kitties_count(), 3);
 
             // check that account #10 owns 1 kitty
             assert_eq!(Kitties::owned_kitty_count(10), 1);
@@ -333,7 +333,7 @@ mod tests {
             assert_eq!(Kitties::owned_kitty_count(5), 0);
 
             // check that this kitty is specifically owned by account #10
-            let hash = Kitties::kitty_by_index(0);
+            let hash = Kitties::kitty_by_index(2);
             assert_eq!(Kitties::owner_of(hash), Some(10));
 
             let other_hash = Kitties::kitty_of_owner_by_index((10, 0));
@@ -355,9 +355,9 @@ mod tests {
 
 			// 10 now has nothing
 			assert_eq!(Kitties::owned_kitty_count(10), 0);
-			// but 1 does
-			assert_eq!(Kitties::owned_kitty_count(1), 1);
-			let new_hash = Kitties::kitty_of_owner_by_index((1, 0));
+			// but 1 now has 2 kitties
+			assert_eq!(Kitties::owned_kitty_count(1), 2;
+			let new_hash = Kitties::kitty_of_owner_by_index((1, 1));
 			// and it has the same hash
 			assert_eq!(hash, new_hash);
 		})

--- a/5/assets/5.3-finished-code.rs
+++ b/5/assets/5.3-finished-code.rs
@@ -218,7 +218,7 @@ impl<T: Trait> Module<T> {
         <OwnedKittiesCount<T>>::insert(&to, new_owned_kitty_count);
         <OwnedKittiesIndex<T>>::insert(kitty_id, owned_kitty_count);
 
-        Self::deposit_event(RawEvent::Created(to, kitty_id));
+        // Self::deposit_event(RawEvent::Created(to, kitty_id));
 
         Ok(())
     }

--- a/5/assets/5.3-finished-code.rs
+++ b/5/assets/5.3-finished-code.rs
@@ -50,7 +50,7 @@ decl_storage! {
         Nonce: u64;
     }
 
-	add_extra_genesis {
+    add_extra_genesis {
         config(kitties): Vec<(T::AccountId, T::Hash, T::Balance)>;
         
         build(|storage: &mut StorageOverlay, _: &mut ChildrenStorageOverlay, config: &GenesisConfig<T>| {

--- a/5/assets/5.3-finished-code.rs
+++ b/5/assets/5.3-finished-code.rs
@@ -306,8 +306,6 @@ mod tests {
 	}
 
 	type Kitties = super::Module<KittiesTest>;
-	type Balances = balances::Module<KittiesTest>;
-	type System = system::Module<KittiesTest>;
 
 	fn build_ext() -> TestExternalities<Blake2Hasher> {
 		let mut t = system::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0;

--- a/5/assets/5.3-template.rs
+++ b/5/assets/5.3-template.rs
@@ -289,8 +289,6 @@ mod tests {
 	}
 
 	type Kitties = super::Module<KittiesTest>;
-	type Balances = balances::Module<KittiesTest>;
-	type System = system::Module<KittiesTest>;
 
 	fn build_ext() -> TestExternalities<Blake2Hasher> {
 		let mut t = system::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0;

--- a/5/assets/5.3-template.rs
+++ b/5/assets/5.3-template.rs
@@ -244,8 +244,6 @@ impl<T: Trait> Module<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-	// Import a bunch of dependencies from substrate core. All needed for some parts of the code.
 	use support::{impl_outer_origin, assert_ok, assert_noop};
 	use runtime_io::{with_externalities, TestExternalities};
 	use primitives::{H256, Blake2Hasher};
@@ -259,13 +257,9 @@ mod tests {
 		pub enum Origin for KittiesTest {}
 	}
 
-	// Create one configuration type (`Test`) which `impl`s each of the
-	// configuration traits of modules we want to use.
 	#[derive(Clone, Eq, PartialEq)]
 	pub struct KittiesTest;
 
-	// Start implementing the Trait's of all the other modules that you need.
-	// If you want anything that is reasonably functional you also need to implement the System trait.
 	impl system::Trait for KittiesTest {
 		type Origin = Origin;
 		type Index = u64;
@@ -280,8 +274,6 @@ mod tests {
 		type Log = DigestItem;
 	}
 	
-    // And any other trait that your Trait is explicitly bounded by.
-	// Remember you had: `pub trait Trait: balances::Trait`
 	impl balances::Trait for KittiesTest {
 		type Balance = u64;
 		type OnFreeBalanceZero = ();
@@ -292,12 +284,10 @@ mod tests {
 		type DustRemoval = ();
 	}
 
-	// And finally, your own trait.
 	impl super::Trait for KittiesTest {
 		type Event = ();
 	}
 
-	// Creates aliases for modules for easier access
 	type Kitties = super::Module<KittiesTest>;
 	type Balances = balances::Module<KittiesTest>;
 	type System = system::Module<KittiesTest>;
@@ -307,6 +297,7 @@ mod tests {
 		t.extend(balances::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0);
 
 		// ACTION: pass in your genesis data here
+        
 		t.into()
 	}
 

--- a/5/configuring-genesis.md
+++ b/5/configuring-genesis.md
@@ -1,2 +1,0 @@
-Setup Test Genesis
-

--- a/5/introduction.md
+++ b/5/introduction.md
@@ -7,5 +7,4 @@ This next section will cover writing tests for your Substrate runtime. Tests are
 
 While you can test some of your code logic through the UI, it is best practice to write unit tests for each runtime module. Unit tests should cover the core functions of your runtime.
 
-Conveniently, Substrate has some low-level primitives that help you execute your runtime tests with minimum hassle, meanwhile giving it capabilities such as calling other modules and processing blocks to be as realistic as possible.
-
+Conveniently, Substrate has some configurations that help you execute your runtime tests with minimum hassle.

--- a/5/setting-up-tests.md
+++ b/5/setting-up-tests.md
@@ -102,12 +102,10 @@ impl system::Trait for KittiesTest {
 
 At this point, we are ready to access and build the modules we just implemented traits for.
 
-Let's assign some type aliases to more easily access these modules going forward.
+Let's assign a type alias to the Kitties module in order to easily access its methods going forward.
 
 ```rust
 type Kitties = super::Module<KittiesTest>;
-type Balances = balances::Module<KittiesTest>;
-type System = system::Module<KittiesTest>;
 ```
 
 > **Note:** All modules are built in a way that the `Module` struct wraps all functions attached to it, hence the syntax `system::Module<KittiesTest>`.

--- a/5/setting-up-tests.md
+++ b/5/setting-up-tests.md
@@ -58,7 +58,7 @@ impl_outer_origin! {
 
 Now we are ready to construct a mock runtime for our tests. 
 
-First, we declare a main configuration type `KittiesTest`. `KittiesTest` will implement each of the configuration traits of modules used by the Kitties runtime, such as `system` and 	`balances`.
+First, we declare a main configuration type `KittiesTest`. `KittiesTest` will implement each of the configuration traits of modules used by the Kitties runtime, such as `system` and `balances`.
 
 This mock runtime can be structured as follows:
 

--- a/5/setting-up-tests.md
+++ b/5/setting-up-tests.md
@@ -1,9 +1,8 @@
 Setting Up Tests
 ===
 
-We start by creating a `test` module inside `substratekitties.rs` as follows. 
-
-> **Note:** Alternatively, you can also refactor this out into its own `test.rs` file.
+Our tests will require support code, so let's start by creating its own `test` module.
+You can place this module inside `substratekitties.rs` as follows (alternatively, you can also refactor this out into its own `test.rs` file).
 
 **substratekitties<span>.</span>rs**
 ```rust
@@ -14,6 +13,7 @@ mod tests {
 	// Your tests
 }
 ```
+The `#[cfg(test)]` attribute declares the entire `tests` module to be testing-only code.
 
 Next, we import some test dependencies from external modules. Most of these modules are used to replace the config types of the traits that we want to implement in the test. 
 

--- a/5/testing-genesis.md
+++ b/5/testing-genesis.md
@@ -67,7 +67,8 @@ build(|storage: &mut StorageOverlay, _: &mut ChildrenStorageOverlay, config: &Ge
 	with_storage(storage, || {
 		for &(ref acct, hash, balance) in &config.kitties {
 
-			let k = Kitty {	id: hash,
+			let k = Kitty {	
+					id: hash,
 					dna: hash,
 					price: balance,
 					gen: 0
@@ -106,8 +107,10 @@ fn build_ext() -> TestExternalities<Blake2Hasher> {
 	let mut t = system::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0;
 	t.extend(balances::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0);
 	t.extend(GenesisConfig::<KittiesTest> {
-		kitties: vec![	(0, H256::random(), 50),
-				(1, H256::zero(), 100)], 
+		
+		// Your genesis kitties 
+		kitties: vec![	(0, H256::random(), 50), (1, H256::zero(), 100)], 
+
 	}.build_storage().unwrap().0);
 	t.into()
 }
@@ -151,7 +154,7 @@ fn should_build_genesis_kitties() {
 In the scope of this tutorial, we'll only review how to set up your genesis state
 for testing. 
 
-At this point, if you want to see how to configure the genesis block for an actual deployment, check out these
+At this point, you might want to see how to configure the genesis block for an actual deployment. You can check out these
 [chain specifications](https://github.com/paritytech/polkadot/blob/d102d8fbac950abf2a696097d65ec2edc64dc216/service/src/chain_spec.rs)
 for our Alexander testnet.
 

--- a/5/testing-genesis.md
+++ b/5/testing-genesis.md
@@ -97,7 +97,7 @@ Recall that you created an initial mock for tests using `TextExternalities`, whe
 used default values for the initial chain state.
 
 In the same function, you can now specify the initial `kitties` configuration. 
-For simplicity, let's seed the chain with the following kitties: 
+For simplicity, let's seed the chain with the following 2 kitties: 
 - 1 kitty with random DNA, belonging to account #0, worth 50 balance.
 - 1 kitty with blank DNA, belonging to account #1, worth 100 balance.
 
@@ -106,8 +106,8 @@ fn build_ext() -> TestExternalities<Blake2Hasher> {
 	let mut t = system::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0;
 	t.extend(balances::GenesisConfig::<KittiesTest>::default().build_storage().unwrap().0);
 	t.extend(GenesisConfig::<KittiesTest> {
-		kitties: vec![  (0, H256::random(), 50), 
-						(1, H256::zero(), 100)], 
+		kitties: vec![	(0, H256::random(), 50),
+				(1, H256::zero(), 100)], 
 	}.build_storage().unwrap().0);
 	t.into()
 }
@@ -115,8 +115,9 @@ fn build_ext() -> TestExternalities<Blake2Hasher> {
 
 ## Test Genesis
 
-If you set up your genesis configurations correctly, you should be able to successfully run
+By now, if you set up your genesis correctly, you should be able to successfully run
 the following test: 
+
 ```rust
 #[test]
 fn should_build_genesis_kitties() {
@@ -138,13 +139,13 @@ fn should_build_genesis_kitties() {
 	})
 }
 ```
+> Note: At this point, your previous tests will fail. You may wish to update your previous tests so they pass given the new genesis configs.
 
 # Your Turn!
 
 - Set up your genesis specs as specified above.
 - Write some new tests to ensure that kitties are correctly configured at genesis.
 - Refactor your previous tests to take advantage of this setup.
-- Update your previous tests so they pass given the new genesis configs.
 
 ### Genesis Deployment
 In the scope of this tutorial, we'll only review how to set up your genesis state

--- a/5/testing-genesis.md
+++ b/5/testing-genesis.md
@@ -1,30 +1,73 @@
 Testing Genesis
 ===
 
-By meow, you may have noticed that the test setup can get quite tededious,
+Right about meow, you may have noticed that the test setup can get quite tedious,
 i.e. having to create new kitties for each unit test.
 
-Wouldn't it be great to deploy our blockchain with some existing kitties in the genesis block?
+Wouldn't it be great to deploy our blockchain with some kitties already minted in the genesis block?
 
-Substrate lets you deploy your chain with preconfigured storage.
-You can allow a genesis configuration for your Substrate modules.
+Substrate lets you deploy your chain with preconfigured storage through a genesis configuration.
 
 In this section, we'll walk you through: 
-- Extending `decl_storage` to add the extra genesis
-- Mocking the genesis configuration in tests
+- Extending `decl_storage` to add extra genesis data
+- Mocking the genesis configuration in during testing
 - Testing that we have the correct genesis set up
 
-## setting up kitties genesis
+## Add Extra Genesis
 
-Let's start by importing the following types and traits from runtime_io at the top of your file.
+Let's start by importing some functions and types we'll be using to configure genesis.
 
 **substratekitties<span>.</span>rs**
 ```rust
 use runtime_io::{with_storage, StorageOverlay, ChildrenStorageOverlay};
 ```
-in kitties, we might want to deploy the chain already specifying: 
-- some accounts
-- having those accounts already own kitties
+Notably:
+- `with_storage`: is a function that takes a closure with global functions. This function lets you populate the runtime storage.
+- `StorageOverlay`: is a set of key value pairs for storage. This represents where your storage resides.
+
+Meow, let's configure our chain's genesis to accept some initial kitties, with predefined DNA & value.
+And let's assign those kitties to designed owners.
+
+Inside `decl_storage` scope, create a struct called `add_extra_genesis` with the following implementation. 
+
+```rust
+decl_storage! {
+    trait Store for Module<T: Trait> as KittyStorage { ... }
+
+    add_extra_genesis {
+        config(kitties): Vec<(T::AccountId, T::Hash, T::Balance)>;
+        
+        build(|storage: &mut StorageOverlay, _: &mut ChildrenStorageOverlay, config: &GenesisConfig<T>| {
+            with_storage(storage, || {
+                for &(ref acct, hash, balance) in &config.kitties {
+
+                    let k = Kitty {
+                                id: hash,
+                                dna: hash,
+                                price: balance,
+                                gen: 0
+                            };
+                
+                    let _ = <Module<T>>::mint(acct.clone(), hash, k);
+                }
+            });
+        });
+    }
+}
+```
+The `config` attribute declares a `kitty` configuration, which is a vector of tuples containing the following types: 
+- AccountId: this will be the owner of the kitty
+- Hash: This is the dna and id of the kitty
+- Balance: This is the initial value of the kitty
+
+This is how you will pass in your seed data, which we'll revisit shortly. 
+
+The `build` attribute 
+The `decl_storage` macro takes care of building the storage. 
+
+
+
+Vec<(T::AccountId, T::Hash, T::Balance)>;
 
 you can see an example of this in...
 when you run the node, you'll do it up in chainspec. but we won't go into that much detail here

--- a/5/testing-genesis.md
+++ b/5/testing-genesis.md
@@ -125,6 +125,7 @@ fn should_build_genesis_kitties() {
 - Set up your genesis specs as specified above.
 - Write some new tests to ensure that kitties are correctly configured at genesis.
 - Refactor your previous tests to take advantage of this setup.
+- Update your previous tests so they pass given the new genesis configs.
 
 ### Genesis Deployment
 In the scope of this tutorial, we'll only review how to set up your genesis state

--- a/5/writing-tests.md
+++ b/5/writing-tests.md
@@ -16,8 +16,12 @@ fn it_works() {
 }
 ```
 
-The command for executing this test is: 
-`cargo test substratekitties.rs` or if want to test your entire package, simply run `cargo test -p YOUR_PACKAGE_NAME`.
+The command for executing this test is:
+`cargo test -p substratekitties-runtime substratekitties`
+
+You can read this line as run the `substratekitties` unit test which is inside the `substratekitties-runtime` sub-package. This verbose specification is necessary because your runtime is nested inside of another Substrate package. 
+
+Conversely, if want to test your entire runtime package, you can also run `cargo test -p substratekitties-runtime`.
 
 The test should pass with the following console output: 
 

--- a/5/writing-tests.md
+++ b/5/writing-tests.md
@@ -90,15 +90,20 @@ You may want to frequently make use of:
 
 ## Your Turn!
 
-Now it is your turn. To complete this section, write the following two tests:
+Now it is your turn. To complete this section, try writing tests for the following expectations:
   - Owner can successfull transfer a kitty.
   - A non-owner will failt to transfer a kitty. Specifically, make sure your test will expectedly fail on the check: `ensure!(owner == from, "'from' account does not own this kitty");`
 
 You are encouraged to write as many tests as you can at this point. 
 
-After a few tests, you might notice that your tests require some common, manual setup (e.g. create 10 kitties for 10 account). Repeating this setup in each test is... well, not fun. 
+## Challenge
+After a few tests, you might notice that your tests require some common, manual setup (e.g. create 10 kitties for 10 accounts). Repeating this setup in each test is... well, not fun. 
 
-Thankfully, __not repeating yourself__ is one of the main design intentions behind Substrate and there is a way to get around it. We will cover this in the next section.
+Thankfully, __not repeating yourself__ is one of the main design intentions behind Substrate and there is a way to get around it.
+
+Our challenge to the reader is to extend the test functionality by giving Kitties runtime a `genesis config`. 
+
+Setting a genesis config allows you to preconfigure the state of the chain before the first block. This is useful in scenarios when we want to initialize the chain to have certain parameters for subsequent transactions.
 
 <!-- tabs:start -->
 

--- a/5/writing-tests.md
+++ b/5/writing-tests.md
@@ -76,7 +76,7 @@ Notable things from the above snippet:
 
 ```rust
 use super::KittyOwner;
-use support::StorageMap;
+use support::StorageMap; //Or: StorageValue, DoubleMap, etc. depending on the value type
 assert_eq!(<KittyOwner<KittiesTest>>::get(hash), Some(10));
 ```
 

--- a/5/writing-tests.md
+++ b/5/writing-tests.md
@@ -91,8 +91,8 @@ You may want to frequently make use of:
 ## Your Turn!
 
 Now it is your turn. To complete this section, try writing tests for the following expectations:
-  - Owner can successfull transfer a kitty.
-  - A non-owner will failt to transfer a kitty. Specifically, make sure your test will expectedly fail on the check: `ensure!(owner == from, "'from' account does not own this kitty");`
+  - Owner can successfully transfer a kitty.
+  - A non-owner will fail to transfer a kitty. Specifically, make sure your test expectedly fails with an error message of: `"'from' account does not own this kitty"`
 
 You are encouraged to write as many tests as you can at this point. 
 
@@ -101,9 +101,9 @@ After a few tests, you might notice that your tests require some common, manual 
 
 Thankfully, __not repeating yourself__ is one of the main design intentions behind Substrate and there is a way to get around it.
 
-Our challenge to the reader is to extend the test functionality by giving Kitties runtime a `genesis config`. 
+Our challenge to the reader is to extend the test functionality by giving Kitties runtime a `genesis config`, which allows you to preconfigure the state of the chain before the first block. A genesis config is useful in scenarios when we want to initialize the chain to have certain parameters for subsequent transactions. In this case, it could be helpful to have some initial kitties to start the game and to make subsequent testing easier.
 
-Setting a genesis config allows you to preconfigure the state of the chain before the first block. This is useful in scenarios when we want to initialize the chain to have certain parameters for subsequent transactions.
+You can see another sample tutorial which implements the genesis config [here](https://docs.substrate.dev/docs/building-the-substrate-tcr-runtime#section-using-the-genesis-config).
 
 <!-- tabs:start -->
 

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -44,9 +44,8 @@
 
 - [**#5 Tests**](5/introduction.md)
 
-    - [Setting up a Test](5/setting-up-tests.md)
-    - [Writing a Test](5/writing-tests.md)
-    <!-- - [Configuring Genesis](5/configuring-genesis.md) -->
+    - [Set Up Tests](5/setting-up-tests.md)
+    - [Writing Tests](5/writing-tests.md)
 
 - [**Extras**](Extras/)
     - **Kitty Auction**

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -46,6 +46,7 @@
 
     - [Set Up Tests](5/setting-up-tests.md)
     - [Writing Tests](5/writing-tests.md)
+    - [Testing Genesis](5/testing-genesis.md)
 
 - [**Extras**](Extras/)
     - **Kitty Auction**


### PR DESCRIPTION
**Ready for review**

For #51 . Shout out to @Kianenigma for crux of 5.1-5.2. 

Concepts addressed include: 
- Section 5.1: setting up the mock for unit tests in substrate, which dependencies to import, how to impl traits for modules, test_externalities

- Section 5.2: writing unit tests for substrate, best practice around ensures, commonly used macros

- Section 5.3: updating test mock to set up genesis configs using build/with_storage. Demonstrates a new way to configure genesis not covered yet in other tutorials.
