### PR TITLE
Replace not visible titles #### with better reaadable **. Fix typo

### DIFF
--- a/steps/30/README.md
+++ b/steps/30/README.md
@@ -69,7 +69,7 @@ Well, SCALE is:
 	- Viable and useful for APIs like: `MaxEncodedLen` and `TypeInfo`
 	- It does not use Rust `std`, and thus can compile to Wasm `no_std`.
 - Consensus critical / bijective; one value will always encode to one blob and that blob will only decode to that value.
-- Supports a copy-free decode for basic types on LE architectures (like Wasm).
+- Supports a copy-free decode for basic types on LE (Little-Endian) architectures (like Wasm).
 - It is about as thin and lightweight as can be.
 
 What you need to know about SCALE is that it defines how every object in the `polkadot-sdk` is represented in bytes.
@@ -97,7 +97,7 @@ Metadata exposes all the details of your blockchain to the outside world, allowi
 
 We won't really use this in this tutorial, but it is super relevant to learn about once you start getting ready to actually use your blockchain.
 
-#### Skip Type Params
+**Skip Type Params**
 
 One nasty thing about the `TypeInfo` derive macro, is that it isn't very "smart".
 

--- a/steps/34/README.md
+++ b/steps/34/README.md
@@ -24,7 +24,7 @@ In general iteration should be avoided where possible, but if unavoidable it is 
 
 We literally cannot allow code on our blockchain which would do unbounded iteration, else that would stall our blockchain, which needs to produce a new block on a regular time interval.
 
-#### Maps
+**Maps**
 
 When you store and iterate over a map, you need to make two considerations:
 
@@ -35,7 +35,7 @@ If you want to do iteration, probably you do NOT want to use a map for exactly t
 
 Maps are great instead for when you need to access or manipulate a single item at a time.
 
-#### Vec
+**Vec**
 
 When you store and iterate over a vector, the only real consideration you need to have is how large that vector is.
 
@@ -45,7 +45,7 @@ Once you access the vector, iterating over it and manipulating it is relatively 
 
 If you want to do iteration, you definitely would prefer to use a vector.
 
-#### Middle Ground
+**Middle Ground**
 
 But sometimes you need to iterate over data, and store a lot of data. This is where we can do a middle ground.
 
@@ -59,7 +59,7 @@ However, if we ALSO store a vector of kitties owned by Shawn in another storage,
 
 A key part of designing your storage is making it efficient for the tasks your code will need to execute. Similarly, you will need to design your code to be efficient for the storage constraints you have.
 
-Honestly, its a lose / lose situation most times, but it is part of what we need to do when designing blockchain systems.
+Honestly, its a lose / lose situation most times, but it is a part of what we need to do when designing blockchain systems.
 
 ## Storage Optimizations
 
@@ -75,7 +75,7 @@ KittiesOwned::<T>::insert(owner, owned_kitties);
 
 The first call we need to make is `get` which returns to us all the data in the vector, and all that data is stored in a merkle trie in a database that is really expensive to read from.
 
-Then we add the item to the vector, and then write the whole new item back into storage.
+Then we add the item to the vector, and then write the whole vector back into storage.
 
 But this is way more inefficient than we need! We don't actually need to know what is inside the vector to add a new item to it, we can just say "add this item".
 

--- a/steps/5/README.md
+++ b/steps/5/README.md
@@ -21,7 +21,7 @@ This is just regular Rust and how you would implement functions on a struct.
 
 ## Trait Implementations
 
-Imagine we had a trait `Hooks` we wanted to implement, we would also use the `Pallet` struct to to that:
+Imagine we had a trait `Hooks` we wanted to implement, we would also use the `Pallet` struct to do that:
 
 ```rust
 impl<T: Config> Hooks for Pallet<T> {

--- a/steps/8/README.md
+++ b/steps/8/README.md
@@ -9,7 +9,7 @@ pub trait Config: frame_system::Config {
 }
 ```
 
-It sucks to keep repeating this about different parts of FRAME development, but the full power of the `Config` trait can only be understood once you have moved passed the basics.
+It sucks to keep repeating this about different parts of FRAME development, but the full power of the `Config` trait can only be understood once you have passed the basics.
 
 For now, we just want to focus on the basics.
 


### PR DESCRIPTION
There is an issue with displaying #### in the dotcodeschool:
https://dotcodeschool.com/courses/substrate-kitties/lesson/3/chapter/4

Titles with level 4 #### look very similar to the normal text.
With **{text}** it will look like "You cannot panic inside the runtime." here:
https://dotcodeschool.com/courses/substrate-kitties/lesson/2/chapter/4

Also fixes few minor test typos, clarifications.