### PR TITLE
rewrite README to focus on the tutorial (closes #188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,39 @@
 # Substrate Collectables Workshop
 
-This repository is the basis for a tutorial teaching how to develop a simple NFT marketplace using the [`polkadot-sdk`](https://github.com/paritytech/polkadot-sdk).
+A guided, hands-on tutorial for building a simple NFT marketplace pallet with the [Polkadot SDK](https://github.com/paritytech/polkadot-sdk).
 
 <img src="./screenshot.png" width="400px" />
 
-> If you are looking for the previous version of this tutorial from 2020, you can find all the original source code on the [`docsify-old` branch](https://github.com/shawntabrizi/substrate-collectables-workshop/tree/docsify-old). However, this content is way out of date, hence this new tutorial! :)
+## Read the Tutorial
+
+The tutorial is published as an interactive book:
+
+**👉 https://www.shawntabrizi.com/substrate-collectables-workshop/**
+
+That is the recommended way to follow along. This repository is the source.
 
 ## Goal
 
-The goal of this tutorial is to **teach by experience** various entry level concepts around Polkadot Pallet development.
+Teach entry-level Polkadot pallet development **by experience**. By the end you will have written a custom pallet that mints, transfers, and trades collectable "kitties" — an on-chain NFT marketplace.
 
-The tutorial is designed to be completed by anyone with basic familiarity with [Rust](https://www.rust-lang.org/), and little to no familiarity with the [Polkadot SDK](https://github.com/paritytech/polkadot-sdk).
+## Who It's For
 
-If you do not feel comfortable with the level of Rust used in this tutorial, we recommend you first check out the [`rust-state-machine`](https://github.com/shawntabrizi/rust-state-machine) tutorial.
+Anyone with basic [Rust](https://www.rust-lang.org/) familiarity and little to no Polkadot SDK background.
 
-## How To Use
+If you are not yet comfortable with the Rust used here, start with the [`rust-state-machine`](https://github.com/shawntabrizi/rust-state-machine) tutorial first.
 
-This repository is not meant to be used directly, but as the source for generating an interactive tutorial using the source code and readme files included at each commit.
+## Repository Layout
 
-This repository manages 3 branches, each with its own history and purpose:
+This repo is the source for the published tutorial, split across three branches:
 
-- [`master`](https://github.com/shawntabrizi/substrate-collectables-workshop/): This is an expanded version of each step and file of the tutorial. Each step has its own full source code and README which is used for that step in the tutorial.
-- [`gitorial`](https://github.com/shawntabrizi/substrate-collectables-workshop/tree/gitorial): This branch repackages all the steps of the tutorial into a single Git history. You can actually take a [look at the history](https://github.com/shawntabrizi/substrate-collectables-workshop/commits/gitorial/) of the `gitorial` branch, and see how each steps evolves using the Git diff.
-- `mdbook`: This is a special repackaging of the tutorial for generating an [mdBook](https://github.com/rust-lang/mdBook) that can be directly used by students.
+- [`master`](https://github.com/shawntabrizi/substrate-collectables-workshop/) — each step of the tutorial as a full, standalone source tree under `steps/`. **Start here for small fixes.**
+- [`gitorial`](https://github.com/shawntabrizi/substrate-collectables-workshop/tree/gitorial) — the same content repackaged as a linear Git history, one commit per step.
+- `mdbook` — the content packaged for rendering as the published [mdBook](https://github.com/rust-lang/mdBook).
 
-If you have small changes that need to be made to a single step, feel free to open an issue or make a PR against the `master` branch. However, for more complex changes which may affect multiple steps, consider learning more about the `gitorial` format.
+## Contributing
 
-### More about Gitorial
+For typos or changes scoped to a single step, open an issue or PR against `master`.
 
-The heart of this tutorial is the [Gitorial format](https://github.com/gitorial-sdk).
+For changes that span multiple steps, the `gitorial` branch is the right place to edit — the Gitorial format and its tooling live at **[gitorial-sdk](https://github.com/gitorial-sdk)**. See that organization for details on the commit conventions, the CLI, and how to keep the three branches in sync.
 
-If you browse the [commit history](https://github.com/shawntabrizi/substrate-collectables-workshop/commits/gitorial/) of the `gitorial` branch, you will see that each commit is designed to be a single step in the tutorial.
-
-All commits are prefixed with one of:
-
-- `section`: This denotes the beginning of a new set of steps which will have a specific goal. These commits will only have changes to the `README.md` file which can be used to introduce the new section of the tutorial.
-- `template`: This is the commit has a `README.md` that teaches the reader any information needed to complete the step. It will also include files with `TODO` comments, telling the user what specifically needs to be done. A `template` will always be followed by a `solution`.
-- `solution`: These commits will always come after a `template` commit. These commits will have the final state of all files in the project at the end of a step. Commits prefixed with `solution` should always compile, run and test successfully (compiler warning are okay). The `template` and `solution` commits should be presented together so reads can compare their work to a working solution. These commits can also be used to generate a `diff` of the step. The `README.md` file in this commit does not need to be presented to the user.
-- `action`: This denotes a step in the tutorial where the user needs to complete some action, not necessarily write any code. For example, the user might need to import a new crate. In this case, it does not make sense to have a `template` and `solution`, but just the final outcome after the action was taken. The previous commit can be used for generating a `diff`. The `README.md` file should contain any information the user needs to complete the action successfully.
-- `readme`: This is only applied to the last commit in this repo, and denotes that this commit was specifically for make a `README.md` for users that browse this repository on github. This step should not be used in the tutorial generation.
-
-You can use Git to make changes to the history of the repo, and then use `git merge` to propagate those changes cleanly into the rest of your repo.
-
-## Maintenance
-
-Maintaining the repo means keeping all three of the main branches in sync.
-
-For this, you can use the [`gitorial-cli`](https://github.com/gitorial-sdk/cli).
-
-Once you have made changes to the appropriate branch, you can use these commands to get all branches in order:
-
-- Convert `master` to an up to date `gitorial` branch:
-
-    ```sh
-	gitorial-cli repack -p /path/to/substrate-collectables-workshop -i master -s steps -o gitorial2
-	```
-
-	Then check your work, and `git reset --hard` the `gitorial` branch with `gitorial2`.
-
-- Convert `gitorial` to an up to date `mdbook` branch:
-
-	```sh
-	gitorial-cli mdbook -p /path/to/substrate-collectables-workshop -i gitorial -o mdbook
-	```
-
-- Convert `gitorial` to an up to date `master` branch:
-
-	```sh
-	gitorial-cli unpack -p /path/to/substrate-collectables-workshop -i gitorial -o master -s steps
-	```
+> Looking for the original 2020 version of this tutorial? It lives on the [`docsify-old` branch](https://github.com/shawntabrizi/substrate-collectables-workshop/tree/docsify-old). The content there is out of date — this rewrite supersedes it.


### PR DESCRIPTION
## Summary
- Leads the README with a prominent link to the hosted tutorial at https://www.shawntabrizi.com/substrate-collectables-workshop/
- Removes the gitorial format deep-dive (commit prefix list, maintenance CLI commands); links out to [gitorial-sdk](https://github.com/gitorial-sdk) instead
- Keeps the three-branch layout summary, the `rust-state-machine` prerequisite pointer, and the `docsify-old` note

Closes #188.

## Test plan
- [ ] README renders cleanly on GitHub
- [ ] All outbound links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)